### PR TITLE
[BUG FIX] - Update signers array after revoking confirmation

### DIFF
--- a/contracts/MultisigWallet.sol
+++ b/contracts/MultisigWallet.sol
@@ -139,11 +139,20 @@ contract MultisigWallet {
         uint _txIndex
     ) public onlyOwner txExists(_txIndex) notExecuted(_txIndex) {
         Transaction storage transaction = transactions[_txIndex];
+        address[] storage signers = transaction.signers;
 
         require(isConfirmed[_txIndex][msg.sender], "tx not confirmed");
 
         transaction.numConfirmations -= 1;
         isConfirmed[_txIndex][msg.sender] = false;
+
+        for (uint i = 0; i < signers.length; i++) {
+            if (signers[i] == msg.sender) {
+                signers[i] = signers[signers.length - 1];
+                signers.pop();
+                break;
+            }
+        }
 
         emit RevokeConfirmation(msg.sender, _txIndex);
     }


### PR DESCRIPTION
The revoke function currently only reduces the number of confirmation + gets rid of the signer from the isConfirmed mapping, but the Transaction struct (specifically the signers array) is not updated. 

This PR resolves this issue by looping through the signers array and moves the address in the signers array to the last position and proceeds to .pop() it.