### PR TITLE
ERC1155 Support

### DIFF
--- a/contracts/MultisigWallet.sol
+++ b/contracts/MultisigWallet.sol
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-contract MultisigWallet {
+import "@openzeppelin/contracts/token/ERC1155/utils/ERC1155Holder.sol";
+
+contract MultisigWallet is ERC1155Holder {
     event Deposit(address indexed sender, uint amount, uint balance);
     event SubmitTransaction(
         address indexed owner,


### PR DESCRIPTION
Currently, trying to send ERC1155s to the contract will cause the following error:

`execution reverted: ERC1155: transfer to non ERC1155Receiver implementer`.

I've added the relevant openZeppelin contract to enable the Multisig Wallet to receive ERC1155 NFTs.