### PR TITLE
Add support for receiving ERC721 tokens

### DIFF
--- a/contracts/MultisigWallet.sol
+++ b/contracts/MultisigWallet.sol
@@ -2,8 +2,9 @@
 pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC1155/utils/ERC1155Holder.sol";
+import "@openzeppelin/contracts/token/ERC721/utils/ERC721Holder.sol";
 
-contract MultisigWallet is ERC1155Holder {
+contract MultisigWallet is ERC1155Holder, ERC721Holder {
     event Deposit(address indexed sender, uint amount, uint balance);
     event SubmitTransaction(
         address indexed owner,


### PR DESCRIPTION
users are currently getting this error
![telegram-cloud-photo-size-4-5958823986110513437-y](https://github.com/pepebndc/solidity-multisig/assets/95218070/f700b956-0c7c-4af0-90ab-a0af8e1948ef)

in order to mitigate this issue, the multisig needs to be able to receive ERC721 tokens which requires inheriting the ERC721Receiver contract